### PR TITLE
Renames auth components methods for clarity

### DIFF
--- a/src/auth/components/ChangePassword.js
+++ b/src/auth/components/ChangePassword.js
@@ -19,7 +19,7 @@ class ChangePassword extends Component {
     [event.target.name]: event.target.value
   })
 
-  changePassword = event => {
+  onChangePassword = event => {
     event.preventDefault()
 
     const { oldPassword, newPassword } = this.state
@@ -36,7 +36,7 @@ class ChangePassword extends Component {
     const { oldPassword, newPassword } = this.state
 
     return (
-      <form className='auth-form' onSubmit={this.changePassword}>
+      <form className='auth-form' onSubmit={this.onChangePassword}>
         <h3>Change Password</h3>
 
         <label htmlFor="oldpw">Old Password</label>

--- a/src/auth/components/SignIn.js
+++ b/src/auth/components/SignIn.js
@@ -19,7 +19,7 @@ class SignIn extends Component {
     [event.target.name]: event.target.value
   })
 
-  signIn = event => {
+  onSignIn = event => {
     event.preventDefault()
 
     const { email, password } = this.state
@@ -38,7 +38,7 @@ class SignIn extends Component {
     const { email, password } = this.state
 
     return (
-      <form className='auth-form' onSubmit={this.signIn}>
+      <form className='auth-form' onSubmit={this.onSignIn}>
         <h3>Sign In</h3>
         <label htmlFor="email">Email</label>
         <input

--- a/src/auth/components/SignUp.js
+++ b/src/auth/components/SignUp.js
@@ -20,7 +20,7 @@ class SignUp extends Component {
     [event.target.name]: event.target.value
   })
 
-  signUp = event => {
+  onSignUp = event => {
     event.preventDefault()
 
     const { email, password, passwordConfirmation} = this.state
@@ -41,7 +41,7 @@ class SignUp extends Component {
     const { email, password, passwordConfirmation} = this.state
 
     return (
-      <form className='auth-form' onSubmit={this.signUp}>
+      <form className='auth-form' onSubmit={this.onSignUp}>
         <h3>Sign Up</h3>
 
         <label htmlFor="email">Email</label>


### PR DESCRIPTION
This pull request renames auth components with confusing naming conventions. 

For example, `src/auth/components/SignIn.js` had a method `signIn` which was called `onSubmit`
in the sign-in form. Within this method was a different method also named `signIn`, which was imported from `src/auth/api.js`. The form now calls a method, `onSignIn`, which contains the `signIn` from api.js