### PR TITLE
Sets image from NPS Api as background image in ExploreParks Component

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -38,6 +38,7 @@ $charcoal: #ccc;
   background-image: url('./images/yosemite_2k-px.jpg');
   background-size: cover;
   background-repeat: no-repeat;
+  background-position: center;
   display: flex;
   height: 92vh;
   flex-direction: column;
@@ -53,6 +54,10 @@ $charcoal: #ccc;
 }
 
 .exploreParks {
+  background-image: url('./images/yosemite_2k-px.jpg');
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center;
   display: flex;
   height: 92vh;
   flex-direction: column;

--- a/src/parks/components/ExploreParks.js
+++ b/src/parks/components/ExploreParks.js
@@ -9,7 +9,8 @@ class ExploreParks extends Component {
     super()
 
     this.state = {
-      parks: []
+      parks: [],
+      image: null
     }
   }
 
@@ -22,15 +23,21 @@ class ExploreParks extends Component {
 
     getAllParks(user)
       .then(res => res.json())
-      .then(res => this.setState(
-        { parks: res.parks }
-      ))
+      .then(res => {
+        this.setState(
+          { parks: res.parks, image: res.parks[0].images[0].url }
+        )
+        return res
+      })
+      .then()
       .catch(console.error)
   }
 
   render () {
+
+    const background = { backgroundImage: 'url(' + this.state.image + ')' }
     return (
-      <div className='exploreParks'>
+      <div className='exploreParks' style={background}>
         { this.state.parks[0] && <h1>{this.state.parks[0].name}</h1>}
         <div className='buttons'>
           <button><Link to="/exploreParks/park">Learn More about Park</Link></button>


### PR DESCRIPTION
This pull request sets image urls from the NPS api to this.state, which then dynamically sets the background style for the ExploreParks.

Two example, after manually changing the parks index.


<img width="1000" alt="acadia screenshot" src="https://user-images.githubusercontent.com/35355802/51260356-1c1fdc80-197c-11e9-97a2-96bfd396d1fd.png">
<img width="1000" alt="denali screenshot" src="https://user-images.githubusercontent.com/35355802/51260385-2641db00-197c-11e9-82ad-ce43fbb9b778.png">


Also styles the background image of ExploreParks component to match the styles of Home.
Next step is to create an input that will toggle between the park objects stored in this.state.parks as well as set this.state.image to the url in the chosen park object.

Advances #2. 