### PR TITLE
Adds parks dropdown with dynamic logic 

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -71,12 +71,28 @@ $charcoal: #ccc;
   flex-direction: column;
   width: 100%;
   align-items: center;
+  // padding: 10px;
+  // margin: 10px;
 
-  button {
+  select {
+    &:focus {
+      outline: none;
+    }
+    
     width: 30%;
     border-radius: 20px;
     height: 50px;
-    margin: 5px 0;
+    margin: 15px 0;
+  }
+
+  button {
+    &:focus {
+      outline: none;
+    }
+    width: 30%;
+    border-radius: 20px;
+    height: 50px;
+    margin: 15px 0;
   }
 }
 

--- a/src/parks/components/ExploreParks.js
+++ b/src/parks/components/ExploreParks.js
@@ -51,7 +51,10 @@ class ExploreParks extends Component {
           )) }
         </select>
         <div className='buttons'>
-          <button><Link to="/exploreParks/park">Learn More about Park</Link></button>
+          <button>
+            <Link to="/exploreParks/park">Learn More about { this.state.currentPark
+                && <span> {this.state.currentPark.name} </span> }
+            </Link></button>
         </div>
       </div>
     )

--- a/src/parks/components/ExploreParks.js
+++ b/src/parks/components/ExploreParks.js
@@ -45,12 +45,12 @@ class ExploreParks extends Component {
     return (
       <div className='exploreParks' style={background}>
         { this.state.currentPark && <h1>{this.state.currentPark.name}</h1>}
-        <select name='currentPark' onChange={this.handleChange}>
-          { this.state.parks.map((park, parkIndex) => (
-            <option key={ parkIndex } value={ parkIndex }>{ park.name }</option>
-          )) }
-        </select>
         <div className='buttons'>
+          <select name='currentPark' onChange={this.handleChange}>
+            { this.state.parks.map((park, parkIndex) => (
+              <option key={ parkIndex } value={ parkIndex }>{ park.name }</option>
+            )) }
+          </select>
           <button>
             <Link to="/exploreParks/park">Learn More about { this.state.currentPark
                 && <span> {this.state.currentPark.name} </span> }

--- a/src/parks/components/ExploreParks.js
+++ b/src/parks/components/ExploreParks.js
@@ -10,13 +10,17 @@ class ExploreParks extends Component {
 
     this.state = {
       parks: [],
-      image: null
+      image: null,
+      currentPark: null
     }
   }
 
-  handleChange = event => this.setState({
-    [event.target.name]: event.target.value
-  })
+  handleChange = event => {
+    this.setState({
+      currentPark: this.state.parks[event.target.value],
+      image: this.state.parks[event.target.value].images[0].url
+    })
+  }
 
   componentDidMount () {
     const { user } = this.props
@@ -25,7 +29,9 @@ class ExploreParks extends Component {
       .then(res => res.json())
       .then(res => {
         this.setState(
-          { parks: res.parks, image: res.parks[0].images[0].url }
+          { parks: res.parks,
+            image: res.parks[0].images[0].url,
+            currentPark: res.parks[0]}
         )
         return res
       })
@@ -38,7 +44,12 @@ class ExploreParks extends Component {
     const background = { backgroundImage: 'url(' + this.state.image + ')' }
     return (
       <div className='exploreParks' style={background}>
-        { this.state.parks[0] && <h1>{this.state.parks[0].name}</h1>}
+        { this.state.currentPark && <h1>{this.state.currentPark.name}</h1>}
+        <select name='currentPark' onChange={this.handleChange}>
+          { this.state.parks.map((park, parkIndex) => (
+            <option key={ parkIndex } value={ parkIndex }>{ park.name }</option>
+          )) }
+        </select>
         <div className='buttons'>
           <button><Link to="/exploreParks/park">Learn More about Park</Link></button>
         </div>


### PR DESCRIPTION
This pull request allows the user to dynamically change the page's content using a `<select>` dropdown in ExploreParks component.

On the api request chain, setState now also sets `currentPark` to `res.parks[0]`. Elements on the page now get their data from `this.state.currentPark` instead of a hardcoded parks index. The `<options>` in ` <select>` are generated by mapping through `this.state.parks` and adds parkIndex as the value for each `<option>`. When the user selects a park in the dropdown, the parkIndex is used to set `this.state` for the `image` and `currentPark` keys, and re-renders the page with the new state.

This new logic dynamically changes the background image and park name displayed on the page based on the chosen `<select>` option.

Advances #2 .

Two examples:

<img width="1000" alt="amistad with dropdown" src="https://user-images.githubusercontent.com/35355802/51274937-7e89d480-199e-11e9-8ea5-b42a72a3391a.png">
<img width="1000" alt="yosemite with dropdown" src="https://user-images.githubusercontent.com/35355802/51274938-7e89d480-199e-11e9-8fe2-bc855a6f1e31.png">
