### PR TITLE
Moves ExploreParks state keys to the parent component, App.js

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,13 +18,18 @@ class App extends Component {
     this.state = {
       user: null,
       flashMessage: '',
-      flashType: null
+      flashType: null,
+      parks: [],
+      image: null,
+      currentPark: null
     }
   }
 
   setUser = user => this.setState({ user })
 
   clearUser = () => this.setState({ user: null })
+
+  setParks = ({parks, image, currentPark}) => this.setState({ parks, image, currentPark })
 
   flash = (message, type) => {
     this.setState({ flashMessage: message, flashType: type })
@@ -36,7 +41,7 @@ class App extends Component {
   }
 
   render () {
-    const { flashMessage, flashType, user } = this.state
+    const { flashMessage, flashType, user, parks, image, currentPark } = this.state
 
     return (
       <React.Fragment>
@@ -48,7 +53,12 @@ class App extends Component {
             <Home flash={this.flash} />
           )} />
           <Route exact path='/exploreParks' render={() => (
-            <ExploreParks flash={this.flash} user={user}/>
+            <ExploreParks flash={this.flash} user={user}
+              parks={parks}
+              image={image}
+              currentPark={currentPark}
+              setParks={this.setParks}/>
+          )} />
           )} />
           <Route path='/sign-up' render={() => (
             <SignUp flash={this.flash} setUser={this.setUser} />

--- a/src/parks/components/ExploreParks.js
+++ b/src/parks/components/ExploreParks.js
@@ -8,27 +8,24 @@ class ExploreParks extends Component {
   constructor () {
     super()
 
-    this.state = {
-      parks: [],
-      image: null,
-      currentPark: null
-    }
   }
 
   handleChange = event => {
-    this.setState({
-      currentPark: this.state.parks[event.target.value],
-      image: this.state.parks[event.target.value].images[0].url
+    const { parks, setParks } = this.props
+    setParks({
+      parks,
+      currentPark: parks[event.target.value],
+      image: parks[event.target.value].images[0].url
     })
   }
 
   componentDidMount () {
-    const { user } = this.props
+    const { user, setParks, parks, image, currentPark } = this.props
 
     getAllParks(user)
       .then(res => res.json())
       .then(res => {
-        this.setState(
+        setParks(
           { parks: res.parks,
             image: res.parks[0].images[0].url,
             currentPark: res.parks[0]}
@@ -40,21 +37,24 @@ class ExploreParks extends Component {
   }
 
   render () {
+    const { parks, image, currentPark } = this.props
 
-    const background = { backgroundImage: 'url(' + this.state.image + ')' }
+    const background = { backgroundImage: 'url(' + image + ')' }
     return (
       <div className='exploreParks' style={background}>
-        { this.state.currentPark && <h1>{this.state.currentPark.name}</h1>}
+        { currentPark && <h1>{currentPark.name}</h1>}
         <div className='buttons'>
           <select name='currentPark' onChange={this.handleChange}>
-            { this.state.parks.map((park, parkIndex) => (
+            { parks.map((park, parkIndex) => (
               <option key={ parkIndex } value={ parkIndex }>{ park.name }</option>
             )) }
           </select>
           <button>
-            <Link to="/exploreParks/park">Learn More about { this.state.currentPark
-                && <span> {this.state.currentPark.name} </span> }
-            </Link></button>
+            { currentPark &&
+              <Link to={'/exploreParks/parks/' + currentPark.name }>Learn More about { currentPark.name }
+              </Link>
+            }
+          </button>
         </div>
       </div>
     )

--- a/src/parks/parksApi.js
+++ b/src/parks/parksApi.js
@@ -1,7 +1,7 @@
 const apiUrl = 'http://localhost:4741'
 
 export const getAllParks = ( user ) => (
-  user
+  user && user.list
     ? fetch(apiUrl + '/exploreParks/' + user.userList)
     : fetch(apiUrl + '/exploreParks/' + '0')
 )


### PR DESCRIPTION
This pull request refactors the `ExploreParks` and `App` components so that components other than ExploreParks can access the `parks`, `image` and `currentPark` state.

App.js now holds these keys and ExploreParks changes the state of App.js through the `setParks` method, passed down as a prop. parks, image, and currentPark are also passed down to ExploreParks as props and destructuring of this.props occurs in all methods that require those keys.

These changes prep for feature #3 so that a Park Component could use the currentPark and image state.