### PR TITLE
Creates Park Component

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import './App.scss'
-import { Route, Link } from 'react-router-dom'
+import { Route, Link, Redirect } from 'react-router-dom'
 
 import AuthenticatedRoute from './auth/components/AuthenticatedRoute'
 import Header from './header/Header'
@@ -10,6 +10,7 @@ import SignOut from './auth/components/SignOut'
 import ChangePassword from './auth/components/ChangePassword'
 import Home from './parks/components/Home'
 import ExploreParks from './parks/components/ExploreParks'
+import Park from './parks/components/Park'
 
 class App extends Component {
   constructor () {
@@ -59,6 +60,14 @@ class App extends Component {
               currentPark={currentPark}
               setParks={this.setParks}/>
           )} />
+          <Route path='/exploreParks/parks' render={() => (
+            !this.state.parks[0]
+              ? <Redirect to='/' />
+              :<Park flash={this.flash}
+                user={user}
+                parks={parks}
+                image={image}
+                currentPark={currentPark}/>
           )} />
           <Route path='/sign-up' render={() => (
             <SignUp flash={this.flash} setUser={this.setUser} />

--- a/src/App.scss
+++ b/src/App.scss
@@ -66,6 +66,36 @@ $charcoal: #ccc;
   padding: 50px 0;
 }
 
+.park {
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center;
+  display: flex;
+  height: 92vh;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  padding: 50px 0;
+}
+
+.info {
+  p {
+    font-size: 20px;
+  }
+
+  h6 {
+    font-size: 22px;
+  }
+
+  background: rgba(400, 400, 400, 0.8);
+  border-radius: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px;
+  width: 50%;
+}
+
 .buttons {
   display: flex;
   flex-direction: column;
@@ -78,7 +108,7 @@ $charcoal: #ccc;
     &:focus {
       outline: none;
     }
-    
+
     width: 30%;
     border-radius: 20px;
     height: 50px;

--- a/src/parks/components/Park.js
+++ b/src/parks/components/Park.js
@@ -1,0 +1,65 @@
+import React, { Component } from 'react'
+import { Route, Link } from 'react-router-dom'
+import { getAllParks } from '../parksApi'
+
+
+
+class Park extends Component {
+  constructor () {
+    super()
+
+    this.state = {
+      currentImage: 0
+    }
+  }
+
+  handleChange = (event) => {
+    const change = event.target.value
+    console.log( this.state.currentImage + Number(change))
+    this.setState(prev => {
+      return {currentImage: prev.currentImage + Number(change) }
+    })
+  }
+
+  // use redirect to stop direct access
+
+  render () {
+
+    const { parks, image, currentPark } = this.props
+
+    const parkImage = currentPark.images
+
+    const background = { backgroundImage: 'url(' + parkImage[this.state.currentImage].url + ')' }
+    return (
+      <div className='park' style={background}>
+        { currentPark &&
+          <React.Fragment>
+            <h1>{currentPark.name}</h1>
+            <div className='info'>
+              <h6>{currentPark.fullName}</h6>
+              <p>{currentPark.description}</p>
+            </div>
+          </React.Fragment>
+        }
+
+        <div className='buttons'>
+          { parkImage[this.state.currentImage - 1] &&
+              <button value={-1} onClickCapture={this.handleChange}>
+                Prev Picture
+              </button> }
+          { parkImage[this.state.currentImage + 1] &&
+              <button value={1} onClickCapture={this.handleChange}>
+                Next Picture
+              </button> }
+          <button>
+            { currentPark &&
+              <Link to={'/exploreParks/parks/' + currentPark.name }> Add { currentPark.name } to Favorite Parks</Link>
+            }
+          </button>
+        </div>
+      </div>
+    )
+  }
+}
+
+export default Park


### PR DESCRIPTION
This pull request creates the `Park` component, which shows more detailed information about the selected park and allows the user to cycle through park images.

Also adds the styling (mostly copied from .exploreParks) for the Park component, the route to it (in App.js) and a redirect to the homepage if a user tries to access this component when `this.state.parks[0]` is undefined. Previous Picture button is rendered only if `parkImage[this.state.currentImage - 1]` is truthy, and Next Picture Button is rendered only if `parkImage[this.state.currentImage + 1]` is truthy.

Closes #3

Some Screenshots:

<img width="1000" alt="park component grand canyon image0 screenshot" src="https://user-images.githubusercontent.com/35355802/51327418-45ee0780-1a3f-11e9-87f6-25a394134937.png">
<img width="1000" alt="park component grand canyon image1 screenshot" src="https://user-images.githubusercontent.com/35355802/51327423-48e8f800-1a3f-11e9-8fce-2ffe2b0adc61.png">

