### PR TITLE
User create and add/remove favoriteParks

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -67,7 +67,8 @@ class App extends Component {
                 user={user}
                 parks={parks}
                 image={image}
-                currentPark={currentPark}/>
+                currentPark={currentPark}
+                setUser={this.setUser}/>
           )} />
           <Route path='/sign-up' render={() => (
             <SignUp flash={this.flash} setUser={this.setUser} />

--- a/src/parks/components/Park.js
+++ b/src/parks/components/Park.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { Route, Link, withRouter } from 'react-router-dom'
-import { getAllParks } from '../parksApi'
+import { addToParks } from '../parksApi'
 
 
 
@@ -22,14 +22,27 @@ class Park extends Component {
   }
 
   addFavorite = event => {
-    const { user, history } = this.props
+    const { user, history, flash, setUser } = this.props
 
     const favorite = event.target.value
 
-    console.log('you here')
 
     user
-      ? console.log('you signed in')
+      ? addToParks(user, favorite)
+        .then(res => res.json())
+        .then(res => {
+          setUser(
+            {
+              userList: res.favoriteParks._id,
+              email: user.email,
+              token: user.token,
+              _id: user._id
+            }
+          )
+          return res
+        }
+        )
+        .catch(console.error)
       : history.push('/sign-in')
   }
   // use redirect to stop direct access

--- a/src/parks/components/Park.js
+++ b/src/parks/components/Park.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Route, Link } from 'react-router-dom'
+import { Route, Link, withRouter } from 'react-router-dom'
 import { getAllParks } from '../parksApi'
 
 
@@ -13,7 +13,7 @@ class Park extends Component {
     }
   }
 
-  handleChange = (event) => {
+  handleChange = event => {
     const change = event.target.value
     console.log( this.state.currentImage + Number(change))
     this.setState(prev => {
@@ -21,11 +21,22 @@ class Park extends Component {
     })
   }
 
+  addFavorite = event => {
+    const { user, history } = this.props
+
+    const favorite = event.target.value
+
+    console.log('you here')
+
+    user
+      ? console.log('you signed in')
+      : history.push('/sign-in')
+  }
   // use redirect to stop direct access
 
   render () {
 
-    const { parks, image, currentPark } = this.props
+    const { parks, image, currentPark, user } = this.props
 
     const parkImage = currentPark.images
 
@@ -51,15 +62,15 @@ class Park extends Component {
               <button value={1} onClickCapture={this.handleChange}>
                 Next Picture
               </button> }
-          <button>
-            { currentPark &&
-              <Link to={'/exploreParks/parks/' + currentPark.name }> Add { currentPark.name } to Favorite Parks</Link>
-            }
-          </button>
+          { currentPark &&
+            <button onClickCapture={this.addFavorite} value={currentPark.parkCode}>
+              Add { currentPark.name } to Favorite Parks
+            </button>
+          }
         </div>
       </div>
     )
   }
 }
 
-export default Park
+export default withRouter(Park)

--- a/src/parks/parksApi.js
+++ b/src/parks/parksApi.js
@@ -1,7 +1,36 @@
 const apiUrl = 'http://localhost:4741'
 
 export const getAllParks = ( user ) => (
-  user && user.list
+  user && user.userList
     ? fetch(apiUrl + '/exploreParks/' + user.userList)
     : fetch(apiUrl + '/exploreParks/' + '0')
+)
+
+export const addToParks = (user, favorite) => (
+
+  user.userList
+    ? fetch(apiUrl + '/favoriteParks/' + user.userList + '/updateOne', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization':`Token token=${user.token}`
+      },
+      body: JSON.stringify({
+        favoriteParks: {
+          list: favorite
+        }
+      })
+    })
+    : fetch(apiUrl + '/favoriteParks', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization':`Token token=${user.token}`
+      },
+      body: JSON.stringify({
+        favoriteParks: {
+          list: favorite
+        }
+      })
+    })
 )


### PR DESCRIPTION
This pull request allows a user to add or remove a park from their favoriteParks.list, and if they do not already have a favoriteParks.list creates one for them.

When a user clicks add in the Parks Component, they call the /updateOne or /create endpoint in the api. If the user is not signed in, they are redirected to the SignIn page. Still need to have the copy on the button change if the user already has that park on their favoriteParks.list.
Upon a successful create or updateOne, setUser is called so that a local copy of the userList is stored.
The ui does not reflect any change in the favoriteParks list.