### PR TITLE
Show Favorites / Frontend refactor

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -29,6 +29,7 @@ class App extends Component {
       flashMessage: '',
       flashType: null,
       parks: [],
+      favoriteParksData: null,
       image: null,
       currentPark: null
     }
@@ -43,7 +44,7 @@ class App extends Component {
   setParks = ({parks, image, currentPark}) => this.setState({ parks, image, currentPark })
 
   // a method passed down as props for setting state for parks
-  updateParks = ({parks}) => this.setState({parks})
+  setFavorites = ({favoriteParksData}) => this.setState({favoriteParksData})
 
   // flash messaging method passed down as a prop.
   flash = (message, type) => {
@@ -56,7 +57,7 @@ class App extends Component {
   }
 
   render () {
-    const { flashMessage, flashType, user, parks, image, currentPark } = this.state
+    const { flashMessage, flashType, user, parks, image, currentPark, favoriteParksData } = this.state
 
     return (
       <React.Fragment>
@@ -79,21 +80,23 @@ class App extends Component {
             fetched, they are redirected to the home page */
             !this.state.parks[0]
               ? <Redirect to='/' />
-              :<Park flash={this.flash}
+              :<Park
+                flash={this.flash}
                 user={user}
                 parks={parks}
                 image={image}
                 currentPark={currentPark}
-                setUser={this.setUser}/>
+                setUser={this.setUser}
+                setFavorites={this.setFavorites}/>
           )} />
           <Route path='/favorites' render={() => (
             !user
               ? <Redirect to='/' />
               : <Favorites
-                updateParks={this.updateParks}
+                setFavorites={this.setFavorites}
                 flash={this.flash}
                 user={user}
-                parks={parks}/>
+                favoriteParksData={favoriteParksData}/>
           )} />
           <Route path='/sign-up' render={() => (
             <SignUp flash={this.flash} setUser={this.setUser} />

--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import ChangePassword from './auth/components/ChangePassword'
 import Home from './parks/components/Home'
 import ExploreParks from './parks/components/ExploreParks'
 import Park from './parks/components/Park'
+import Favorites from './parks/components/Favorites'
 
 class App extends Component {
   constructor () {
@@ -40,6 +41,9 @@ class App extends Component {
 
   // a method passed down as props for setting state for parks, image and currentPark
   setParks = ({parks, image, currentPark}) => this.setState({ parks, image, currentPark })
+
+  // a method passed down as props for setting state for parks
+  updateParks = ({parks}) => this.setState({parks})
 
   // flash messaging method passed down as a prop.
   flash = (message, type) => {
@@ -81,6 +85,15 @@ class App extends Component {
                 image={image}
                 currentPark={currentPark}
                 setUser={this.setUser}/>
+          )} />
+          <Route path='/favorites' render={() => (
+            !user
+              ? <Redirect to='/' />
+              : <Favorites
+                updateParks={this.updateParks}
+                flash={this.flash}
+                user={user}
+                parks={parks}/>
           )} />
           <Route path='/sign-up' render={() => (
             <SignUp flash={this.flash} setUser={this.setUser} />

--- a/src/header/Header.js
+++ b/src/header/Header.js
@@ -17,20 +17,13 @@ const unauthenticatedOptions = (
   </React.Fragment>
 )
 
-const alwaysOptions = (
-  <React.Fragment>
-    <Link to="/">Home</Link>
-  </React.Fragment>
-)
-
 const Header = ({ user }) => (
   <header className="main-header">
-    <h4>National Park Finder</h4>
+    <h4><Link to="/">National Park Finder</Link></h4>
     { user && user.userFavorites && <Link to="/favorites">My favorites</Link>}
     <nav>
       { user && <span>Welcome, {user.email}</span>}
       { user ? authenticatedOptions : unauthenticatedOptions }
-      { alwaysOptions }
     </nav>
   </header>
 )

--- a/src/header/Header.js
+++ b/src/header/Header.js
@@ -26,7 +26,7 @@ const alwaysOptions = (
 const Header = ({ user }) => (
   <header className="main-header">
     <h4>National Park Finder</h4>
-    { user && user.userList && <Link to="/favorites">My favorites</Link>}
+    { user && user.userFavorites && <Link to="/favorites">My favorites</Link>}
     <nav>
       { user && <span>Welcome, {user.email}</span>}
       { user ? authenticatedOptions : unauthenticatedOptions }

--- a/src/header/Header.js
+++ b/src/header/Header.js
@@ -26,6 +26,7 @@ const alwaysOptions = (
 const Header = ({ user }) => (
   <header className="main-header">
     <h4>National Park Finder</h4>
+    { user && user.userList && <Link to="/favorites">My favorites</Link>}
     <nav>
       { user && <span>Welcome, {user.email}</span>}
       { user ? authenticatedOptions : unauthenticatedOptions }

--- a/src/parks/components/Favorites.js
+++ b/src/parks/components/Favorites.js
@@ -1,0 +1,32 @@
+import React, { Component } from 'react'
+import { Route, Link } from 'react-router-dom'
+import ParkItem from './ParkItem'
+
+class Favorites extends Component {
+  constructor() {
+    super()
+
+    this.state = {}
+  }
+
+  componentDidMount () {
+    // if favorite parks is empty, go fetch them!
+  }
+
+  render () {
+
+    const { parks, updateParks } = this.props
+
+    return (
+      <React.Fragment>
+        <ul>
+          { parks.map((park, parkIndex) => (
+            <ParkItem key={ parkIndex } park={ park } updateParks={ updateParks } />
+          )) }
+        </ul>
+      </React.Fragment>
+    )
+  }
+}
+
+export default Favorites

--- a/src/parks/components/Favorites.js
+++ b/src/parks/components/Favorites.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import { Route, Link } from 'react-router-dom'
+import { showFavorites } from '../parksApi'
 import ParkItem from './ParkItem'
 
 class Favorites extends Component {
@@ -10,19 +11,31 @@ class Favorites extends Component {
   }
 
   componentDidMount () {
-    // if favorite parks is empty, go fetch them!
+    const { favoriteParksData, setFavorites, user } = this.props
+
+    showFavorites(user)
+      .then(res => res.json())
+      .then(res => {
+        setFavorites({favoriteParksData: res.favoriteParksData})
+        return res
+      })
+      .then(res => console.log(favoriteParksData))
+      .catch(console.error)
+
+
   }
 
   render () {
 
-    const { parks, updateParks } = this.props
+    const { favoriteParksData, setFavorites } = this.props
 
     return (
       <React.Fragment>
         <ul>
-          { parks.map((park, parkIndex) => (
-            <ParkItem key={ parkIndex } park={ park } updateParks={ updateParks } />
-          )) }
+          { favoriteParksData &&
+            favoriteParksData.map((park, parkIndex) => (
+              <ParkItem key={ parkIndex } park={ park } setFavorites={ setFavorites } />
+            )) }
         </ul>
       </React.Fragment>
     )

--- a/src/parks/components/Park.js
+++ b/src/parks/components/Park.js
@@ -38,7 +38,7 @@ class Park extends Component {
         .then(res => {
           setUser(
             {
-              userList: res.favoriteParks._id,
+              userFavorites: res.favoriteParks._id,
               email: user.email,
               token: user.token,
               _id: user._id

--- a/src/parks/components/Park.js
+++ b/src/parks/components/Park.js
@@ -25,7 +25,7 @@ class Park extends Component {
 
   // allows a user to add a park to their favoriteParks list.
   addFavorite = event => {
-    const { user, history, flash, setUser } = this.props
+    const { user, history, flash, setUser, setFavorites } = this.props
 
     // grabs the parkCode of the currentPark
     const favorite = event.target.value
@@ -36,9 +36,13 @@ class Park extends Component {
       ? addToParks(user, favorite)
         .then(res => res.json())
         .then(res => {
+          setFavorites( { favoriteParksData: res.favoriteParksData } )
+          return res
+        })
+        .then(res => {
           setUser(
             {
-              userFavorites: res.favoriteParks._id,
+              userFavorites: res.favoriteParksId,
               email: user.email,
               token: user.token,
               _id: user._id
@@ -47,6 +51,7 @@ class Park extends Component {
           return res
         }
         )
+        .then(console.log)
         .catch(console.error)
         // otherwise, redirect the user to sign-in
       : history.push('/sign-in')

--- a/src/parks/components/ParkItem.js
+++ b/src/parks/components/ParkItem.js
@@ -1,0 +1,21 @@
+import React, { Component } from 'react'
+import { Route, Link } from 'react-router-dom'
+
+class ParkItem extends Component {
+  constructor() {
+    super()
+
+    this.state = {}
+  }
+
+  render () {
+
+    const { park, updateParks } = this.props
+
+    return (
+      <li>{ park && park.name}</li>
+    )
+  }
+}
+
+export default ParkItem

--- a/src/parks/components/ParkItem.js
+++ b/src/parks/components/ParkItem.js
@@ -10,10 +10,10 @@ class ParkItem extends Component {
 
   render () {
 
-    const { park, updateParks } = this.props
+    const { park, setFavorites } = this.props
 
     return (
-      <li>{ park && park.name}</li>
+      <li>{ park.fullName }</li>
     )
   }
 }

--- a/src/parks/parksApi.js
+++ b/src/parks/parksApi.js
@@ -6,20 +6,21 @@ import apiUrl from '../apiConfig'
 // the default parks list (if not signed in),
 // or a combination of both (if the user is signed in, but has fewer than 10 favorites.)
 
-// userList contains the _id for a user's favoriteParks if they have one.
+// userFavorites contains the _id for a user's favoriteParks if they have one.
 export const getAllParks = ( user ) => (
-  user && user.userList
-    ? fetch(apiUrl + '/exploreParks/' + user.userList)
+  user && user.userFavorites
+    ? fetch(apiUrl + '/exploreParks/' + user.userFavorites)
     : fetch(apiUrl + '/exploreParks/' + '0')
 )
 
-// if the user has a userList (favoriteParks list)
+// if the user has a userFavorites (favoriteParks list)
 // then pass in the park that will be used to update the list.
-// otherwise create a userList with that item
-export const addToParks = (user, favorite) => (
+// otherwise create a userFavorites with that item
+export const addToParks = (user, favorite) => {
 
-  user.userList
-    ? fetch(apiUrl + '/favoriteParks/' + user.userList + '/updateOne', {
+
+  return user.userFavorites
+    ? fetch(apiUrl + '/favoriteParks/' + user.userFavorites + '/updateOne', {
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',
@@ -43,4 +44,4 @@ export const addToParks = (user, favorite) => (
         }
       })
     })
-)
+}

--- a/src/parks/parksApi.js
+++ b/src/parks/parksApi.js
@@ -13,6 +13,16 @@ export const getAllParks = ( user ) => (
     : fetch(apiUrl + '/exploreParks/' + '0')
 )
 
+export const showFavorites = (user) => (
+  fetch(apiUrl + '/favoriteParks/' + user.userFavorites, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization':`Token token=${user.token}`
+    }
+  })
+)
+
 // if the user has a userFavorites (favoriteParks list)
 // then pass in the park that will be used to update the list.
 // otherwise create a userFavorites with that item


### PR DESCRIPTION
This pull request gives the user the ability to see their Favorite Parks. 

The type of data needed from the api (NPS park objects, as opposed to a list of parkCodes) required an refactor of the api as well as the frontend to handle the new data being returned from the api. The api now only returns `FavoriteParksData` or `FavoriteParksId` when hitting the /favoriteParks routes.

Closes Issue #5 